### PR TITLE
Misc CatalogItem tables + art

### DIFF
--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemArt
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest,
+                lookup: %i[
+                  prep__person
+                ]
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[cultureid schoolid creatorroleid creator2roleid
+                  creator3roleid imagesizeid framesizeid collectorid]
+
+              transform Merge::MultiRowLookup,
+                lookup: prep__person,
+                keycolumn: :creatorid,
+                fieldmap: {creator: :fullname}
+
+              transform Merge::MultiRowLookup,
+                lookup: prep__person,
+                keycolumn: :creator2id,
+                fieldmap: {creator2: :fullname}
+
+              transform Merge::MultiRowLookup,
+                lookup: prep__person,
+                keycolumn: :creator3id,
+                fieldmap: {creator3: :fullname}
+
+              transform Delete::Fields,
+                fields: %i[creatorid creator2id creator3id]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_accessories.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_accessories.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemArtAccessories
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[dictionaryitemid]
+
+              transform Rename::Field,
+                from: :dictionaryitem,
+                to: :accessories
+
+              transform Delete::Fields,
+                fields: %i[position id]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_accessories.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_accessories.rb
@@ -25,9 +25,6 @@ module Kiba
               transform Rename::Field,
                 from: :dictionaryitem,
                 to: :accessories
-
-              transform Delete::Fields,
-                fields: %i[position id]
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_material.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_material.rb
@@ -26,9 +26,6 @@ module Kiba
               transform Rename::Field,
                 from: :dictionaryitem,
                 to: :material
-
-              transform Delete::Fields,
-                fields: %i[position id]
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_material.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_material.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemArtMaterial
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest,
+                lookup: %i[]
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[dictionaryitemid]
+
+              transform Rename::Field,
+                from: :dictionaryitem,
+                to: :material
+
+              transform Delete::Fields,
+                fields: %i[position id]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_medium.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_medium.rb
@@ -26,9 +26,6 @@ module Kiba
               transform Rename::Field,
                 from: :dictionaryitem,
                 to: :medium
-
-              transform Delete::Fields,
-                fields: %i[position id]
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_medium.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_medium.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemArtMedium
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest,
+                lookup: %i[]
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[dictionaryitemid]
+
+              transform Rename::Field,
+                from: :dictionaryitem,
+                to: :medium
+
+              transform Delete::Fields,
+                fields: %i[position id]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_technique.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_technique.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemArtTechnique
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest,
+                lookup: %i[]
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[dictionaryitemid]
+
+              transform Rename::Field,
+                from: :dictionaryitem,
+                to: :technique
+
+              transform Delete::Fields,
+                fields: %i[position id]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_technique.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art_technique.rb
@@ -26,9 +26,6 @@ module Kiba
               transform Rename::Field,
                 from: :dictionaryitem,
                 to: :technique
-
-              transform Delete::Fields,
-                fields: %i[position id]
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_inscription.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_inscription.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemInscription
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest,
+                lookup: %i[]
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[typeid	techniqueid	languageid]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_people.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_people.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemPeople
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest,
+                lookup: :prep__person
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Merge::MultiRowLookup,
+                lookup: prep__person,
+                keycolumn: :personid,
+                fieldmap: {person_name: :fullname}
+
+              transform Delete::Fields,
+                fields: %i[personid position]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_source.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_source.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module CatalogItemSource
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[receivedasid]
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding assundry catalogItem tables that needed prep, plus the prep for Art tab of Object records.

Note, I elected to delete the `position` and `id` columns from the tables CatalogItemArtAccessories, CatalogItemArtMaterial, CatalogItemArtMedium, and CatalogItemArtTechnique with the rationale that the position/sequence was already reflected in the order they appeared in the spreadsheet and rows would be joined accordingly; and that the `id` column was not germane in the ultimate joining to the catalogitem larger record, which would be based on the `catalogitemid` column in the table. Let me know if you disagree with either of these, and I can add the column(s) back.