### PR TITLE
Term source indication; Review namespace and final xforms

### DIFF
--- a/lib/kiba/pastperfect_we/config/terms.rb
+++ b/lib/kiba/pastperfect_we/config/terms.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Terms
+      module_function
+
+      extend Dry::Configurable
+
+
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/config/terms.rb
+++ b/lib/kiba/pastperfect_we/config/terms.rb
@@ -7,7 +7,11 @@ module Kiba
 
       extend Dry::Configurable
 
-
+      # @return [String] value inserted between "term-like value" used in a
+      #   record and its Table.Id source indication
+      setting :term_source_prefix,
+        reader: true,
+        default: " termsrc:"
     end
   end
 end

--- a/lib/kiba/pastperfect_we/config/terms.rb
+++ b/lib/kiba/pastperfect_we/config/terms.rb
@@ -12,6 +12,19 @@ module Kiba
       setting :term_source_prefix,
         reader: true,
         default: " termsrc:"
+
+      # @return [Hash<String => Symbol>] keys are table names; values are the
+      #   fields from PREP jobs that contain the "term-like" values merged into
+      #   other tables
+      setting :table_config,
+        reader: true,
+        default: {
+          "Contact" => :fullname,
+          "LexiconItem" => :objectname,
+          "Person" => :fullname,
+          "Site" => :sitenumberandname,
+          "User" => :fullname
+        }
     end
   end
 end

--- a/lib/kiba/pastperfect_we/jobs/contact/combined.rb
+++ b/lib/kiba/pastperfect_we/jobs/contact/combined.rb
@@ -23,6 +23,12 @@ module Kiba
 
           def xforms
             Kiba.job_segment do
+              transform Ppwe::Transforms::DeleteTermSourceIndication,
+                table: "Contact"
+              transform Ppwe::Transforms::DeleteTermSourceIndication,
+                table: "Contact",
+                term_src: :spouse
+
               transform Ppwe::Transforms::MergeTable,
                 source: :prep__contact_biographical_info,
                 join_column: :id,

--- a/lib/kiba/pastperfect_we/jobs/prep/accession.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/accession.rb
@@ -40,12 +40,12 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__user,
                 keycolumn: :createdbyuserid,
-                fieldmap: {createdby: :fullname}
+                fieldmap: {createdby: Ppwe::Terms.table_config["User"]}
 
               transform Merge::MultiRowLookup,
                 lookup: prep__user,
                 keycolumn: :statusbyuserid,
-                fieldmap: {statusby: :fullname}
+                fieldmap: {statusby: Ppwe::Terms.table_config["User"]}
 
               transform Delete::Fields,
                 fields: %i[statusbyuserid createdbyuserid flagid]

--- a/lib/kiba/pastperfect_we/jobs/prep/archive_container_location.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/archive_container_location.rb
@@ -23,7 +23,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :creatorid,
-                fieldmap: {creator_name: :fullname}
+                fieldmap: {creator_name: Ppwe::Terms.table_config["Person"]}
 
               transform Replace::FieldValueWithStaticMapping,
                 source: :ispublicaccess,

--- a/lib/kiba/pastperfect_we/jobs/prep/archive_identity.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/archive_identity.rb
@@ -29,12 +29,12 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :creatorid,
-                fieldmap: {creator_name: :fullname}
+                fieldmap: {creator_name: Ppwe::Terms.table_config["Person"]}
 
               transform Merge::MultiRowLookup,
                 lookup: prep__site,
                 keycolumn: :siteid,
-                fieldmap: {sitename: :sitename}
+                fieldmap: {sitename: Ppwe::Terms.table_config["Site"]}
 
               transform Delete::Fields,
                 fields: :creatorid

--- a/lib/kiba/pastperfect_we/jobs/prep/archive_identity.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/archive_identity.rb
@@ -37,7 +37,7 @@ module Kiba
                 fieldmap: {sitename: Ppwe::Terms.table_config["Site"]}
 
               transform Delete::Fields,
-                fields: :creatorid
+                fields: %i[creatorid siteid]
 
               transform Ppwe::Transforms::CrSplitter,
                 fields: :creatoraddedentry

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item.rb
@@ -62,12 +62,12 @@ module Kiba
                 transform Merge::MultiRowLookup,
                   lookup: prep__user,
                   keycolumn: :createdbyuserid,
-                  fieldmap: {createdby: :fullname}
+                  fieldmap: {createdby: Ppwe::Terms.table_config["User"]}
 
                 transform Merge::MultiRowLookup,
                   lookup: prep__user,
                   keycolumn: :statusbyuserid,
-                  fieldmap: {statusby: :fullname}
+                  fieldmap: {statusby: Ppwe::Terms.table_config["User"]}
 
                 transform Merge::MultiRowLookup,
                   lookup: prep__lexicon_item,

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_archaeology.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_archaeology.rb
@@ -34,7 +34,7 @@ module Kiba
                 transform Merge::MultiRowLookup,
                   lookup: prep__site,
                   keycolumn: :siteid,
-                  fieldmap: {sitename: :sitename}
+                  fieldmap: {sitename: Ppwe::Terms.table_config["Site"]}
 
                 transform Delete::Fields,
                   fields: %i[siteid]

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_art.rb
@@ -29,17 +29,17 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :creatorid,
-                fieldmap: {creator: :fullname}
+                fieldmap: {creator: Ppwe::Terms.table_config["Person"]}
 
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :creator2id,
-                fieldmap: {creator2: :fullname}
+                fieldmap: {creator2: Ppwe::Terms.table_config["Person"]}
 
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :creator3id,
-                fieldmap: {creator3: :fullname}
+                fieldmap: {creator3: Ppwe::Terms.table_config["Person"]}
 
               transform Delete::Fields,
                 fields: %i[creatorid creator2id creator3id]

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_geology.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_geology.rb
@@ -31,7 +31,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__site,
                 keycolumn: :siteid,
-                fieldmap: {sitename: :sitename}
+                fieldmap: {sitename: Ppwe::Terms.table_config["Site"]}
               transform Delete::Fields,
                 fields: %i[siteid]
             end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_history.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_history.rb
@@ -29,7 +29,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :creatorid,
-                fieldmap: {creator: :fullname}
+                fieldmap: {creator: Ppwe::Terms.table_config["Person"]}
 
               transform Delete::Fields,
                 fields: %i[creatorid]

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_music.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_music.rb
@@ -29,7 +29,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :primaryartistid,
-                fieldmap: {primaryartist: :fullname}
+                fieldmap: {primaryartist: Ppwe::Terms.table_config["Person"]}
 
               transform Delete::Fields,
                 fields: %i[primaryartistid]

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_people.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_people.rb
@@ -26,7 +26,7 @@ module Kiba
                 fieldmap: {person_name: :fullname}
 
               transform Delete::Fields,
-                fields: %i[personid position]
+                fields: %i[personid]
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_people.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_people.rb
@@ -23,7 +23,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :personid,
-                fieldmap: {person_name: :fullname}
+                fieldmap: {person_name: Ppwe::Terms.table_config["Person"]}
 
               transform Delete::Fields,
                 fields: %i[personid]

--- a/lib/kiba/pastperfect_we/jobs/prep/catalog_item_photo.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/catalog_item_photo.rb
@@ -36,12 +36,12 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__person,
                 keycolumn: :photographerid,
-                fieldmap: {photographer: :fullname}
+                fieldmap: {photographer: Ppwe::Terms.table_config["Person"]}
 
               transform Merge::MultiRowLookup,
                 lookup: prep__site,
                 keycolumn: :siteid,
-                fieldmap: {sitename: :sitename}
+                fieldmap: {sitename: Ppwe::Terms.table_config["Site"]}
               transform Delete::Fields,
                 fields: %i[photographerid siteid]
             end

--- a/lib/kiba/pastperfect_we/jobs/prep/contact.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/contact.rb
@@ -50,7 +50,7 @@ module Kiba
                 fieldmap: {createdby: :fullname}
 
               transform Delete::Fields,
-                fields: %i[spouseidcreatedbyuserid flagid]
+                fields: %i[spouseid createdbyuserid flagid]
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/contact.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/contact.rb
@@ -47,7 +47,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__user,
                 keycolumn: :createdbyuserid,
-                fieldmap: {createdby: :fullname}
+                fieldmap: {createdby: Ppwe::Terms.table_config["User"]}
 
               transform Delete::Fields,
                 fields: %i[spouseid createdbyuserid flagid]

--- a/lib/kiba/pastperfect_we/jobs/prep/contact.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/contact.rb
@@ -23,6 +23,9 @@ module Kiba
 
           def xforms
             Kiba.job_segment do
+              transform Ppwe::Transforms::AddTermSourceIndication,
+                table: "Contact"
+
               transform Ppwe::Transforms::DictionaryLookup,
                 fields: %i[groupid]
 
@@ -48,6 +51,12 @@ module Kiba
                 lookup: prep__user,
                 keycolumn: :createdbyuserid,
                 fieldmap: {createdby: Ppwe::Terms.table_config["User"]}
+
+              transform CombineValues::FromFieldsWithDelimiter,
+                sources: %i[spouse spouseid],
+                target: :spouse,
+                delete_sources: false,
+                delim: "#{Ppwe::Terms.term_source_prefix}Contact."
 
               transform Delete::Fields,
                 fields: %i[spouseid createdbyuserid flagid]

--- a/lib/kiba/pastperfect_we/jobs/prep/contact_list.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/contact_list.rb
@@ -32,7 +32,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__user,
                 keycolumn: :listmanagerid,
-                fieldmap: {listmanager: :fullname}
+                fieldmap: {listmanager: Ppwe::Terms.table_config["User"]}
 
               transform Delete::Fields,
                 fields: :listmanagerid

--- a/lib/kiba/pastperfect_we/jobs/prep/image_object.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/image_object.rb
@@ -27,7 +27,7 @@ module Kiba
               transform Merge::MultiRowLookup,
                 lookup: prep__user,
                 keycolumn: :createdbyid,
-                fieldmap: {createdby: :fullname}
+                fieldmap: {createdby: Ppwe::Terms.table_config["User"]}
 
               transform Delete::Fields,
                 fields: :createdbyid

--- a/lib/kiba/pastperfect_we/jobs/prep/lexicon_item.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/lexicon_item.rb
@@ -11,10 +11,7 @@ module Kiba
             Kiba::Extend::Jobs::Job.new(
               files: {
                 source: source,
-                destination: dest,
-                lookup: %i[
-                  prep__user
-                ]
+                destination: dest
               },
               transformer: Ppwe::Prep.get_xforms(self)
             )

--- a/lib/kiba/pastperfect_we/jobs/prep/lexicon_item.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/lexicon_item.rb
@@ -69,6 +69,8 @@ module Kiba
                   row[:objectname] = [term, hier].join(" < ")
                   row
                 end
+                transform Ppwe::Transforms::AddTermSourceIndication,
+                  table: "LexiconItem"
               end
             end
           end

--- a/lib/kiba/pastperfect_we/jobs/prep/person.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/person.rb
@@ -21,7 +21,7 @@ module Kiba
           def xforms
             Kiba.job_segment do
               transform Ppwe::Transforms::DictionaryLookup,
-                fields: %i[museumid roleid]
+                fields: %i[roleid]
 
               %i[iscreator ispublicaccess isremoved].each do |field|
                 transform Replace::FieldValueWithStaticMapping,

--- a/lib/kiba/pastperfect_we/jobs/prep/person.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/person.rb
@@ -20,6 +20,9 @@ module Kiba
 
           def xforms
             Kiba.job_segment do
+              transform Ppwe::Transforms::AddTermSourceIndication,
+                table: "Person"
+
               transform Ppwe::Transforms::DictionaryLookup,
                 fields: %i[roleid]
 

--- a/lib/kiba/pastperfect_we/jobs/prep/site.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/site.rb
@@ -27,6 +27,12 @@ module Kiba
 
               transform Ppwe::Transforms::DictionaryLookup,
                 fields: %i[countryid]
+
+              transform CombineValues::FromFieldsWithDelimiter,
+                sources: %i[sitenumber sitename],
+                target: :sitenumberandname,
+                delete_sources: false,
+                delim: ": "
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/site.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/site.rb
@@ -33,6 +33,9 @@ module Kiba
                 target: :sitenumberandname,
                 delete_sources: false,
                 delim: ": "
+
+              transform Ppwe::Transforms::AddTermSourceIndication,
+                table: "Site"
             end
           end
         end

--- a/lib/kiba/pastperfect_we/jobs/prep/site_archeology_details.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/site_archeology_details.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module SiteArcheologyDetails
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              boolean_fields = %i[isassociatedarchives islevelbags islithics
+                isshellfish iswovenorganics isceramics issedimentsamples
+                isunmodifiedbone ischarcoal ismetal ishistorics
+                isflotationsamples ismodifiedbone isorganics isglass]
+              blankness = boolean_fields.map { |bf| [bf, "0"] }
+                .to_h
+              transform Delete::EmptyFields,
+                consider_blank: blankness
+
+              boolean_fields.each do |field|
+                transform Replace::FieldValueWithStaticMapping,
+                  source: field,
+                  mapping: Ppwe.boolean_yes_no_mapping
+              end
+
+              transform Ppwe::Transforms::DictionaryLookup,
+                fields: %i[projectnameid projecttypeid investigatoraffiliationid
+                  electroniccatalogstatusid rehousingstatusid
+                  controllingagencyid]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/site_mapping_options.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/site_mapping_options.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Prep
+        module SiteMappingOptions
+          module_function
+
+          def job(source:, dest:)
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: source,
+                destination: dest
+              },
+              transformer: Ppwe::Prep.get_xforms(self)
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              blankness = %i[ispositionbasedongps measure elevation].map do |bf|
+                [bf, "0"]
+              end.to_h
+              transform Delete::EmptyFields,
+                consider_blank: blankness
+
+              transform Replace::FieldValueWithStaticMapping,
+                source: :ispositionbasedongps,
+                mapping: Ppwe.boolean_yes_no_mapping
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/prep/url.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/url.rb
@@ -34,7 +34,7 @@ module Kiba
                 transform Merge::MultiRowLookup,
                   lookup: prep__user,
                   keycolumn: :useraddedid,
-                  fieldmap: {useradded: :fullname}
+                  fieldmap: {useradded: Ppwe::Terms.table_config["User"]}
 
                 transform Delete::Fields,
                   fields: %i[useraddedid]

--- a/lib/kiba/pastperfect_we/jobs/prep/user.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/user.rb
@@ -20,9 +20,6 @@ module Kiba
 
           def xforms
             Kiba.job_segment do
-              transform Ppwe::Transforms::DictionaryLookup,
-                fields: %i[museumid]
-
               transform Merge::MultiRowLookup,
                 lookup: preprocess__user_role,
                 keycolumn: :userroleid,

--- a/lib/kiba/pastperfect_we/jobs/prep/user.rb
+++ b/lib/kiba/pastperfect_we/jobs/prep/user.rb
@@ -20,6 +20,9 @@ module Kiba
 
           def xforms
             Kiba.job_segment do
+              transform Ppwe::Transforms::AddTermSourceIndication,
+                table: "User"
+
               transform Merge::MultiRowLookup,
                 lookup: preprocess__user_role,
                 keycolumn: :userroleid,

--- a/lib/kiba/pastperfect_we/jobs/review/contact.rb
+++ b/lib/kiba/pastperfect_we/jobs/review/contact.rb
@@ -3,15 +3,15 @@
 module Kiba
   module PastperfectWe
     module Jobs
-      module Contact
-        module Combined
+      module Review
+        module Contact
           module_function
 
           def job
             Kiba::Extend::Jobs::Job.new(
               files: {
                 source: :prep__contact,
-                destination: :contact__combined,
+                destination: :review__contact,
                 lookup: %i[
                   prep__contact_urls
                   prep__contact_attachments

--- a/lib/kiba/pastperfect_we/jobs/review/lexicon_item.rb
+++ b/lib/kiba/pastperfect_we/jobs/review/lexicon_item.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Review
+        module LexiconItem
+          module_function
+
+          def job
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: :prep__lexicon_item,
+                destination: :review__lexicon_item
+              },
+              transformer: xforms
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DeleteTermSourceIndication,
+                table: "LexiconItem"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/jobs/review/person.rb
+++ b/lib/kiba/pastperfect_we/jobs/review/person.rb
@@ -3,15 +3,15 @@
 module Kiba
   module PastperfectWe
     module Jobs
-      module Person
-        module Combined
+      module Review
+        module Person
           module_function
 
           def job
             Kiba::Extend::Jobs::Job.new(
               files: {
                 source: :prep__person,
-                destination: :person__combined,
+                destination: :review__person,
                 lookup: %i[
                   prep__person_url
                   prep__person_attachment
@@ -23,20 +23,15 @@ module Kiba
 
           def xforms
             Kiba.job_segment do
+              transform Ppwe::Transforms::DeleteTermSourceIndication,
+                table: "Person"
+              transform Delete::Fields,
+                fields: %i[createddate createdbyuserid]
+
               transform Ppwe::Transforms::MergeTable,
                 source: :prep__person_biographical_information,
                 join_column: :id,
-                delete_join_column: false,
-                drop_fields: %i[maritalstatus],
-                opts: {null_placeholder: "FOO",
-                       constantmap: {biomerged: "y"}}
-
-              transform Ppwe::Transforms::MergeTable,
-                source: :prep__person_attachment,
-                join_column: :id,
-                delete_join_column: false,
-                drop_fields: :id,
-                merged_field_prefix: "attachment"
+                delete_join_column: false
 
               transform Count::MatchingRowsInLookup,
                 lookup: prep__person_attachment,

--- a/lib/kiba/pastperfect_we/jobs/review/site.rb
+++ b/lib/kiba/pastperfect_we/jobs/review/site.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Jobs
+      module Review
+        module Site
+          module_function
+
+          def job
+            Kiba::Extend::Jobs::Job.new(
+              files: {
+                source: :prep__site,
+                destination: :review__site
+              },
+              transformer: xforms
+            )
+          end
+
+          def xforms
+            Kiba.job_segment do
+              transform Ppwe::Transforms::DeleteTermSourceIndication,
+                table: "Site"
+
+              transform Ppwe::Transforms::MergeTable,
+                source: :prep__site_archeology_details,
+                join_column: :id,
+                delete_join_column: false
+
+              transform Ppwe::Transforms::MergeTable,
+                source: :prep__site_mapping_options,
+                join_column: :id,
+                delete_join_column: false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/registry_data.rb
+++ b/lib/kiba/pastperfect_we/registry_data.rb
@@ -251,15 +251,6 @@ module Kiba
           }
         end
 
-        Ppwe.registry.namespace("contact") do
-          register :combined, {
-            path: File.join(Ppwe.wrkdir, "contact_combined.csv"),
-            creator: Ppwe::Jobs::Contact::Combined,
-            tags: %i[combined contact],
-            lookup_on: Ppwe.lookup_column_for("Contact")
-          }
-        end
-
         Ppwe.registry.namespace("dictionary") do
           register :filters, {
             path: File.join(Ppwe.wrkdir, "dictionary_filters.csv"),
@@ -325,6 +316,16 @@ module Kiba
             creator: Ppwe::Jobs::Person::Combined,
             tags: %i[combined person],
             lookup_on: Ppwe.lookup_column_for("Person")
+          }
+        end
+
+        Ppwe.registry.namespace("review") do
+          dir = File.join(Ppwe.datadir, "for_review")
+          register :contact, {
+            path: File.join(dir, "contact.csv"),
+            creator: Ppwe::Jobs::Review::Contact,
+            tags: %i[review contact],
+            lookup_on: Ppwe.lookup_column_for("Contact")
           }
         end
       end

--- a/lib/kiba/pastperfect_we/registry_data.rb
+++ b/lib/kiba/pastperfect_we/registry_data.rb
@@ -324,8 +324,12 @@ module Kiba
           register :contact, {
             path: File.join(dir, "contact.csv"),
             creator: Ppwe::Jobs::Review::Contact,
-            tags: %i[review contact],
-            lookup_on: Ppwe.lookup_column_for("Contact")
+            tags: %i[review contact]
+          }
+          register :lexicon_item, {
+            path: File.join(dir, "lexicon_item.csv"),
+            creator: Ppwe::Jobs::Review::LexiconItem,
+            tags: %i[review lexicon_item]
           }
         end
       end

--- a/lib/kiba/pastperfect_we/registry_data.rb
+++ b/lib/kiba/pastperfect_we/registry_data.rb
@@ -327,6 +327,11 @@ module Kiba
             creator: Ppwe::Jobs::Review::Person,
             tags: %i[review person]
           }
+          register :site, {
+            path: File.join(dir, "site.csv"),
+            creator: Ppwe::Jobs::Review::Site,
+            tags: %i[review site]
+          }
         end
       end
       private_class_method :register_files

--- a/lib/kiba/pastperfect_we/registry_data.rb
+++ b/lib/kiba/pastperfect_we/registry_data.rb
@@ -310,15 +310,6 @@ module Kiba
           }
         end
 
-        Ppwe.registry.namespace("person") do
-          register :combined, {
-            path: File.join(Ppwe.wrkdir, "person_combined.csv"),
-            creator: Ppwe::Jobs::Person::Combined,
-            tags: %i[combined person],
-            lookup_on: Ppwe.lookup_column_for("Person")
-          }
-        end
-
         Ppwe.registry.namespace("review") do
           dir = File.join(Ppwe.datadir, "for_review")
           register :contact, {
@@ -330,6 +321,11 @@ module Kiba
             path: File.join(dir, "lexicon_item.csv"),
             creator: Ppwe::Jobs::Review::LexiconItem,
             tags: %i[review lexicon_item]
+          }
+          register :person, {
+            path: File.join(dir, "person.csv"),
+            creator: Ppwe::Jobs::Review::Person,
+            tags: %i[review person]
           }
         end
       end

--- a/lib/kiba/pastperfect_we/transforms/add_term_source_indication.rb
+++ b/lib/kiba/pastperfect_we/transforms/add_term_source_indication.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Transforms
+      # Appends term source indication to term-like value when in review
+      #   mode
+      class AddTermSourceIndication
+        # @param table [String] name of table we're updating
+        # @param term_src [nil, Symbol] field containing term value that will be
+        #   merged into other table(s) as "term-like value"; Looks up from
+        #   Ppwe::Terms.table_config if not provided
+        # @param prefix [String] for the source indication segment
+        def initialize(table:, term_src: nil,
+          prefix: Ppwe::Terms.term_source_prefix)
+          @table = table
+          @term_src = term_src || Ppwe::Terms.table_config[table]
+          @prefix = prefix
+          @mode = Ppwe.mode
+          @id_field = Ppwe.lookup_column_for(table)
+        end
+
+        def process(row)
+          return row unless mode == :review
+
+          val = row[term_src]
+          term = val.blank? ? "{no value}" : val
+          row[term_src] = "#{term}#{prefix}#{table}.#{row[id_field]}"
+          row
+        end
+
+        private
+
+        attr_reader :table, :term_src, :prefix, :mode, :id_field
+      end
+    end
+  end
+end

--- a/lib/kiba/pastperfect_we/transforms/delete_term_source_indication.rb
+++ b/lib/kiba/pastperfect_we/transforms/delete_term_source_indication.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Kiba
+  module PastperfectWe
+    module Transforms
+      # Removes term source indication from term-like value when in review
+      #   mode
+      class DeleteTermSourceIndication
+        # @param table [String] name of table we're updating
+        # @param term_src [nil, Symbol] field containing term value that will be
+        #   merged into other table(s) as "term-like value"; Looks up from
+        #   Ppwe::Terms.table_config if not provided
+        # @param prefix [String] for the source indication segment
+        def initialize(table:, term_src: nil,
+          prefix: Ppwe::Terms.term_source_prefix)
+          @table = table
+          @term_src = term_src || Ppwe::Terms.table_config[table]
+          @prefix = prefix
+          @mode = Ppwe.mode
+        end
+
+        def process(row)
+          return row unless mode == :review
+
+          val = row[term_src]
+          return row if val.blank?
+
+          row[term_src] = val.sub(/#{prefix}.*$/, "")
+          row
+        end
+
+        private
+
+        attr_reader :table, :term_src, :prefix, :mode
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #49 

- Implements addition of term source indication
- Adds "review" namespace for jobs that output final user-facing CSVs (written to "for_review" directory).
- Applies final transform to convert %QUOT%, %CR%, etc. to jobs